### PR TITLE
feat: 지수백오프 재시도 로직 개발

### DIFF
--- a/crawler/src/main/kotlin/com/fx/crawler/adapter/out/message/FcmNotificationAdapter.kt
+++ b/crawler/src/main/kotlin/com/fx/crawler/adapter/out/message/FcmNotificationAdapter.kt
@@ -6,10 +6,11 @@ import com.fx.crawler.common.annotation.NotificationAdapter
 import com.fx.global.domain.FcmToken
 import com.fx.global.domain.Meal
 import com.fx.global.domain.Notice
-import com.google.firebase.messaging.BatchResponse
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import kotlin.collections.plusAssign
@@ -26,13 +27,11 @@ class FcmNotificationAdapter : FcmNotificationPort {
         return withContext(Dispatchers.IO) {
             if (fcmTokens.isEmpty()) return@withContext emptyList()
 
-            val tokens = fcmTokens.map { it.fcmToken }
-            val failedTokens = mutableListOf<FcmToken>()
-
             // 3개 이상인 경우 합쳐서
             // ex) notices = [n1, n2] -> noticeGroups = [[n1], [n2]]
             // ex) notices = [n1, n2, n3] -> noticeGroups = [[n1, n2, n3]]
             val noticeGroups = if (notices.size <= 2) notices.map { listOf(it) } else listOf(notices)
+            val failedTokens = mutableListOf<FcmToken>()
 
             for (group in noticeGroups) {
                 val first = group[0]
@@ -40,11 +39,10 @@ class FcmNotificationAdapter : FcmNotificationPort {
                 // group.size == 1 -> 3개 이상인 경우임
                 val bodyMessage = if (group.size == 1) first.title else buildMessage(group)
 
-                val multicastMessage = MessageFactory.create(tokens, first, bodyMessage)
-                val response = FirebaseMessaging.getInstance().sendEachForMulticast(multicastMessage)
-                failedTokens += extractFailedTokens(fcmTokens, response)
+                failedTokens += sendWithRetry(fcmTokens) { tokens ->
+                    MessageFactory.create(tokens, first, bodyMessage)
+                }
             }
-
 
             failedTokens
         }
@@ -54,43 +52,77 @@ class FcmNotificationAdapter : FcmNotificationPort {
         return withContext(Dispatchers.IO) {
             if (fcmTokens.isEmpty()) return@withContext emptyList()
 
-            val tokens = fcmTokens.map { it.fcmToken }
-
             val bodyMessage = buildMessage(meal)
-            val multicastMessage = MessageFactory.create(tokens, meal, bodyMessage)
-            val response = FirebaseMessaging.getInstance().sendEachForMulticast(multicastMessage)
-            extractFailedTokens(fcmTokens, response)
+
+            sendWithRetry(fcmTokens) { tokens ->
+                MessageFactory.create(tokens, meal, bodyMessage)
+            }
         }
     }
 
     override suspend fun sendSilentPushNotification(fcmTokens: List<FcmToken>): List<FcmToken> {
         return withContext(Dispatchers.IO) {
-            val failedTokens = mutableListOf<FcmToken>()
-
             if (fcmTokens.isEmpty()) return@withContext emptyList()
-            val tokens = fcmTokens.map { it.fcmToken }
 
-            val multicastMessage = MessageFactory.createSilentPush(tokens)
-            val response = FirebaseMessaging.getInstance().sendEachForMulticast(multicastMessage)
-            failedTokens += extractFailedTokens(fcmTokens, response)
-
-            failedTokens
+            sendWithRetry(fcmTokens) { tokens ->
+                MessageFactory.createSilentPush(tokens)
+            }
         }
     }
 
-    private fun extractFailedTokens(fcmTokens: List<FcmToken>, response: BatchResponse): List<FcmToken> {
-        return response.responses.mapIndexedNotNull { index, sendResponse ->
-            if (!sendResponse.isSuccessful && (
-                        sendResponse.exception?.messagingErrorCode == MessagingErrorCode.UNREGISTERED ||
-                        sendResponse.exception?.messagingErrorCode == MessagingErrorCode.INVALID_ARGUMENT)
-            ) fcmTokens[index] else null
+    private suspend fun sendWithRetry(
+        fcmTokens: List<FcmToken>,
+        maxRetries: Int = 3,
+        messageFactory: (List<String>) -> MulticastMessage
+    ): List<FcmToken> {
+        var attempt = 0
+        var waitTime = 1L
+        var currentTokens = fcmTokens
+        val finalFailedTokens = mutableListOf<FcmToken>()
+
+        while (attempt < maxRetries && currentTokens.isNotEmpty()) {
+            attempt++
+            try {
+                val multicastMessage = messageFactory(currentTokens.map { it.fcmToken })
+                val response = FirebaseMessaging.getInstance().sendEachForMulticast(multicastMessage)
+
+                val retryableTokens = mutableListOf<FcmToken>()
+                for ((index, sendResponse) in response.responses.withIndex()) {
+                    if (!sendResponse.isSuccessful) {
+                        when (sendResponse.exception?.messagingErrorCode) {
+                            MessagingErrorCode.UNREGISTERED,
+                            MessagingErrorCode.INVALID_ARGUMENT -> finalFailedTokens += currentTokens[index] // isActive = false 대상
+                            MessagingErrorCode.INTERNAL,
+                            MessagingErrorCode.UNAVAILABLE,
+                            MessagingErrorCode.QUOTA_EXCEEDED -> retryableTokens += currentTokens[index] // 재시도 대상
+                            else -> log.info("서버 오류로 전송할 수 없습니다. : {}", sendResponse.exception?.messagingErrorCode)
+                        }
+                    }
+                }
+
+                if (retryableTokens.isEmpty()) break
+
+                currentTokens = retryableTokens
+                log.warn("일시적 오류 발생, ${waitTime}초 후 재시도 ($attempt/$maxRetries)")
+                delay(waitTime * 1000)
+                waitTime *= 2
+
+            } catch (e: Exception) {
+                log.error("FCM 전송 중 예외 발생: ${e.message}", e)
+                break
+            }
+
         }
+        if (currentTokens.isNotEmpty()) {
+            log.error("최종 실패 토큰 수(재시도 불가): ${currentTokens.size}")
+        }
+
+        return finalFailedTokens
     }
 
     private fun buildMessage(notices: List<Notice>): String {
         return "${notices[0].title} 외 ${notices.size - 1}개의 소식이 있습니다."
     }
-
 
     private fun buildMessage(meal: Meal): String {
         val header = "${meal.mealDate} ${meal.topic.category} 메뉴"

--- a/crawler/src/main/kotlin/com/fx/crawler/adapter/out/message/factory/MessageFactory.kt
+++ b/crawler/src/main/kotlin/com/fx/crawler/adapter/out/message/factory/MessageFactory.kt
@@ -39,7 +39,6 @@ object MessageFactory {
             .addAllTokens(fcmTokens)
             .build()
 
-
     private fun defaultData(notice: Notice): Map<String, String> =
         mapOf(
             "nttId" to notice.nttId.toString(),
@@ -103,4 +102,5 @@ object MessageFactory {
                     .build()
             )
             .build()
+
 }


### PR DESCRIPTION
# feat: 지수백오프 재시도 로직 개발

- 고차함수 적용
- 실패 -> 1초 후 전송, 2초 후 전송, 4초 후 전송 -> 종료
    - `UNREGISTERED`, `INVALID_ARGUMENT` 의 경우 `isActive=false` 처리하도록 하며, **나머지 ErrorCode 만 재시도처리**