### PR TITLE
refactor(global): Update common API response structure

### DIFF
--- a/api/src/main/kotlin/com/fx/api/adapter/out/web/NotificationWebAdapter.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/out/web/NotificationWebAdapter.kt
@@ -13,7 +13,7 @@ class NotificationWebAdapter(
 
     override fun pushTestNotice(pushNotice: PushNotice): Boolean {
         val response = notificationFeignClient.pushTestNotice(pushNotice.fcmToken, createFeignRequestDto(pushNotice))
-        return response.body?.success ?: false
+        return response.body?.metaData?.success ?: false
     }
 
     private fun createFeignRequestDto(pushNotice: PushNotice): NoticeNotificationFeignRequest =

--- a/api/src/main/kotlin/com/fx/api/config/swagger/ApiExceptionExplainParser.kt
+++ b/api/src/main/kotlin/com/fx/api/config/swagger/ApiExceptionExplainParser.kt
@@ -4,6 +4,7 @@ import com.fx.global.annotation.ApiExceptionExplanation
 import com.fx.global.annotation.ApiResponseExplanations
 import com.fx.global.api.Api
 import com.fx.global.api.BaseErrorCode
+import com.fx.global.api.MetaData
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.examples.Example
 import io.swagger.v3.oas.models.media.Content
@@ -95,9 +96,11 @@ object ApiExceptionExplainParser {
                 description: String
             ): Example {
                 val response = Api(
-                    success = false,
-                    code = errorCode.httpStatus.value(),
-                    message = errorCode.message,
+                    metaData = MetaData(
+                        success = false,
+                        code = errorCode.httpStatus.value(),
+                        message = errorCode.message,
+                    ),
                     data = null
                 )
 

--- a/global/src/main/kotlin/com/fx/global/api/Api.kt
+++ b/global/src/main/kotlin/com/fx/global/api/Api.kt
@@ -3,10 +3,14 @@ package com.fx.global.api
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 
-class Api<T>(
+data class MetaData(
     val success: Boolean,
     val code: Int,
-    val message: String?,
+    val message: String?
+)
+
+class Api<T>(
+    val metaData: MetaData,
     val data: T?
 ) {
 
@@ -17,9 +21,11 @@ class Api<T>(
                 .status(HttpStatus.OK)
                 .body(
                     Api(
-                        success = true,
-                        code = HttpStatus.OK.value(),
-                        message = message,
+                        metaData = MetaData(
+                            success = true,
+                            code = HttpStatus.OK.value(),
+                            message = message,
+                        ),
                         data = data
                     )
                 )
@@ -30,9 +36,11 @@ class Api<T>(
                 .status(HttpStatus.OK)
                 .body(
                     Api(
-                        success = true,
-                        code = HttpStatus.OK.value(),
-                        message = null,
+                        metaData = MetaData(
+                            success = true,
+                            code = HttpStatus.OK.value(),
+                            message = null,
+                        ),
                         data = data
                     )
                 )
@@ -43,9 +51,11 @@ class Api<T>(
                 .status(httpStatus)
                 .body(
                     Api(
-                        success = true,
-                        code = httpStatus.value(),
-                        message = null,
+                        metaData = MetaData(
+                            success = true,
+                            code = httpStatus.value(),
+                            message = null,
+                        ),
                         data = data
                     )
                 )
@@ -56,9 +66,11 @@ class Api<T>(
                 .status(httpStatus)
                 .body(
                     Api(
-                        success = true,
-                        code = httpStatus.value(),
-                        message = message,
+                        metaData = MetaData(
+                            success = true,
+                            code = httpStatus.value(),
+                            message = message,
+                        ),
                         data = data
                     )
                 )
@@ -69,9 +81,11 @@ class Api<T>(
                 .status(baseErrorCode.httpStatus)
                 .body(
                     Api(
-                        success = false,
-                        code = baseErrorCode.httpStatus.value(),
-                        message = baseErrorCode.message,
+                        metaData = MetaData(
+                            success = false,
+                            code = baseErrorCode.httpStatus.value(),
+                            message = baseErrorCode.message,
+                        ),
                         data = null
                     )
                 )
@@ -82,9 +96,11 @@ class Api<T>(
                 .status(httpStatus)
                 .body(
                     Api(
-                        success = false,
-                        code = httpStatus.value(),
-                        message = message,
+                        metaData = MetaData(
+                            success = false,
+                            code = httpStatus.value(),
+                            message = message,
+                        ),
                         data = null
                     )
                 )


### PR DESCRIPTION
# refactor(global): Update common API response structure

클라이언트 재활용성 고려하여 변경

### Before
```
{
  "success": true,
  "code": 200,
  "message": "요청 성공",
  "data": { ... }
}
```

### After
```
{
  "metaData": {
    "success": true,
    "code": 200,
    "message": "요청 성공"
  },
  "data": { ... }
}
```
