### PR TITLE
refactor: Jsoup 블로킹 호출을 논블로킹으로 변경

### DIFF
--- a/crawler/build.gradle.kts
+++ b/crawler/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
 
     implementation("io.github.seob7:common-api:0.0.1")
 
+    // Ktor Client (논블로킹 HTTP)
+    implementation("io.ktor:ktor-client-cio:2.3.6")
+
     // Mongo
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 


### PR DESCRIPTION
# refactor: Jsoup 블로킹 호출을 논블로킹으로 변경

- 기존 Jsoup.connect/get 호출은 블로킹 방식이었음
- Ktor HttpClient를 사용하여 HTTP 요청을 논블로킹 방식으로 변경
- HTML 파싱 자체는 Jsoup를 사용하되, 네트워크 호출만 논블로킹으로 수행

## 개선결과
**총 260개의 네트워크 요청 기준**
- 기존 `Jsoup.connect()` 사용 시: 약 830개의 Thread 소모

- 개선 후 `httpClient.get()` 사용 시: 약 75개의 Thread 소모
- 감소율 ≈ 91%