### PR TITLE
!HOTFIX: 토픽 구독 동시 요청 시 Lost Update 오류 수정

### DIFF
--- a/api/src/main/kotlin/com/fx/api/adapter/out/persistence/FcmTokenPersistenceAdapter.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/out/persistence/FcmTokenPersistenceAdapter.kt
@@ -2,14 +2,21 @@ package com.fx.api.adapter.out.persistence
 
 import com.fx.api.adapter.out.persistence.repository.FcmTokenMongoRepository
 import com.fx.api.application.port.out.FcmTokenPersistencePort
+import com.fx.api.application.port.out.dto.TopicUpdateQuery
 import com.fx.global.adapter.out.persistence.document.FcmTokenDocument
 import com.fx.global.annotation.PersistenceAdapter
 import com.fx.global.domain.DeviceType
 import com.fx.global.domain.FcmToken
+import com.fx.global.domain.TopicType
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
 
 @PersistenceAdapter
 class FcmTokenPersistenceAdapter(
-    private val fcmTokenMongoRepository: FcmTokenMongoRepository
+    private val fcmTokenMongoRepository: FcmTokenMongoRepository,
+    private val mongoTemplate: MongoTemplate
 ): FcmTokenPersistencePort {
 
     override fun saveFcmToken(fcmToken: FcmToken) {
@@ -24,5 +31,23 @@ class FcmTokenPersistenceAdapter(
 
     override fun countByIsActiveAndDeviceType(isActive: Boolean, deviceType: DeviceType): Long =
         fcmTokenMongoRepository.countByIsActiveAndDeviceType(isActive, deviceType)
+
+    // 배타락으로 Lost Update 발생 방지
+    override fun atomicUpdateTopic(topicUpdateQuery: TopicUpdateQuery): Boolean {
+        val field = when (topicUpdateQuery.topicType) {
+            TopicType.NOTICE -> "subscribedNoticeTopics"
+            TopicType.MAJOR  -> "subscribedMajorTopics"
+            TopicType.MEAL   -> "subscribedMealTopics"
+        }
+
+        val mongoQuery = Query.query(Criteria.where("_id").`is`(topicUpdateQuery.fcmToken))
+        val update = if (topicUpdateQuery.enabled) {
+            Update().addToSet(field, topicUpdateQuery.topic.topicName)
+        } else {
+            Update().pull(field, topicUpdateQuery.topic.topicName)
+        }
+
+        return mongoTemplate.updateFirst(mongoQuery, update, FcmTokenDocument::class.java).matchedCount > 0
+    }
 
 }

--- a/api/src/main/kotlin/com/fx/api/application/port/out/FcmTokenPersistencePort.kt
+++ b/api/src/main/kotlin/com/fx/api/application/port/out/FcmTokenPersistencePort.kt
@@ -1,5 +1,6 @@
 package com.fx.api.application.port.out
 
+import com.fx.api.application.port.out.dto.TopicUpdateQuery
 import com.fx.global.domain.DeviceType
 import com.fx.global.domain.FcmToken
 
@@ -12,5 +13,11 @@ interface FcmTokenPersistencePort {
     fun existsByFcmToken(fcmToken: String): Boolean
 
     fun countByIsActiveAndDeviceType(isActive: Boolean, deviceType: DeviceType): Long
+
+    /**
+     * MongoDB $addToSet / $pull 연산자로 토픽을 원자적으로 추가/제거
+     * @return 대상 토큰이 존재하면 true, 없으면 false
+     */
+    fun atomicUpdateTopic(topicUpdateQuery: TopicUpdateQuery): Boolean
 
 }

--- a/api/src/main/kotlin/com/fx/api/application/port/out/dto/TopicUpdateQuery.kt
+++ b/api/src/main/kotlin/com/fx/api/application/port/out/dto/TopicUpdateQuery.kt
@@ -1,0 +1,12 @@
+package com.fx.api.application.port.out.dto
+
+import com.fx.global.domain.CrawlableType
+import com.fx.global.domain.TopicType
+
+data class TopicUpdateQuery(
+    val fcmToken: String,
+    val topicType: TopicType,
+    val topic: CrawlableType,
+    val enabled: Boolean
+)
+

--- a/api/src/main/kotlin/com/fx/api/application/service/FcmTokenCommandService.kt
+++ b/api/src/main/kotlin/com/fx/api/application/service/FcmTokenCommandService.kt
@@ -5,7 +5,7 @@ import com.fx.api.application.port.`in`.dto.FcmTokenSaveCommand
 import com.fx.api.application.port.`in`.dto.FcmTokenUpdateCommand
 import com.fx.api.application.port.`in`.dto.TopicUpdateCommand
 import com.fx.api.application.port.out.FcmTokenPersistencePort
-import com.fx.global.domain.TopicType
+import com.fx.api.application.port.out.dto.TopicUpdateQuery
 import com.fx.global.exception.FcmTokenException
 import com.fx.global.exception.errorcode.FcmTokenErrorCode
 import com.fx.global.domain.FcmToken
@@ -67,42 +67,19 @@ class FcmTokenCommandService(
     }
 
     override fun updateTopic(topicUpdateCommand: TopicUpdateCommand): Boolean {
-        val fcmToken = (fcmTokenPersistencePort.findByFcmToken(topicUpdateCommand.fcmToken)
-            ?: throw FcmTokenException(FcmTokenErrorCode.TOKEN_NOT_FOUND))
-
-        val updatedFcmToken = when (topicUpdateCommand.topicType) {
-            TopicType.NOTICE -> fcmToken.copy(
-                subscribedNoticeTopics = updateTopicSet(fcmToken.subscribedNoticeTopics, topicUpdateCommand)
+        val updated = fcmTokenPersistencePort.atomicUpdateTopic(
+            TopicUpdateQuery(
+                fcmToken = topicUpdateCommand.fcmToken,
+                topicType = topicUpdateCommand.topicType,
+                topic = topicUpdateCommand.topic,
+                enabled = topicUpdateCommand.enabled
             )
-            TopicType.MAJOR -> fcmToken.copy(
-                subscribedMajorTopics = updateTopicSet(fcmToken.subscribedMajorTopics, topicUpdateCommand)
-            )
-            TopicType.MEAL -> fcmToken.copy(
-                subscribedMealTopics = updateTopicSet(fcmToken.subscribedMealTopics, topicUpdateCommand)
-            )
+        )
+        if (!updated) {
+            throw FcmTokenException(FcmTokenErrorCode.TOKEN_NOT_FOUND)
         }
-
-        fcmTokenPersistencePort.saveFcmToken(updatedFcmToken)
         return true
     }
-
-    private fun <T: Enum<T>> updateTopicSet(
-        currentTopics: Set<T>,
-        topicUpdateCommand: TopicUpdateCommand
-    ): Set<T> {
-        val updated = currentTopics.toMutableSet()
-
-        @Suppress("UNCHECKED_CAST")
-        val topic = topicUpdateCommand.topic as T
-
-        if (topicUpdateCommand.enabled)
-            updated.add(topic)
-        else
-            updated.remove(topic)
-        return updated
-    }
-
-
 
 
 }

--- a/api/src/test/kotlin/com/fx/api/application/service/FcmTokenCommandServiceTest.kt
+++ b/api/src/test/kotlin/com/fx/api/application/service/FcmTokenCommandServiceTest.kt
@@ -126,62 +126,39 @@ class FcmTokenCommandServiceTest : BehaviorSpec({
             enabled = false
         )
 
-        val mealTopicUpdateCommand = TopicUpdateCommand(
-            fcmToken = fcmTokenStr,
-            topicType = TopicType.MEAL,
-            topic = MealType.STUDENT_CAFETERIA,
-            enabled = false
-        )
-
-        val fcmToken = FcmToken.createFcmToken(
-            fcmTokenStr,
-            DeviceType.iOS
-        )
-
         When("Fcm token 이 존재하지 않는 경우") {
+            clearMocks(fcmTokenPersistencePort)
             every {
-                fcmTokenPersistencePort.findByFcmToken(fcmTokenStr)
-            } returns null
+                fcmTokenPersistencePort.atomicUpdateTopic(any())
+            } returns false
 
             Then("FcmTokenException 예외 발생") {
                 val exception = shouldThrow<FcmTokenException> {
                     fcmTokenCommandService.updateTopic(noticeTopicUpdateCommand)
                 }
-
                 exception.baseErrorCode shouldBe FcmTokenErrorCode.TOKEN_NOT_FOUND
             }
         }
 
-        When("Fcm token 이 존재하는 경유") {
+        When("Fcm token 이 존재하는 경우") {
             clearMocks(fcmTokenPersistencePort)
             every {
-                fcmTokenPersistencePort.findByFcmToken(noticeTopicUpdateCommand.fcmToken)
-            } returns fcmToken
+                fcmTokenPersistencePort.atomicUpdateTopic(any())
+            } returns true
 
-            Then("GENERAL_NEWS Topic 제거") {
+            Then("GENERAL_NEWS Topic 제거 요청이 원자적으로 전달된다") {
                 val result = fcmTokenCommandService.updateTopic(noticeTopicUpdateCommand)
                 result shouldBe true
 
                 verify(exactly = 1) {
-                    fcmTokenPersistencePort.saveFcmToken(match {
-                        it.fcmToken == noticeTopicUpdateCommand.fcmToken && !it.subscribedNoticeTopics.contains(
-                            NoticeType.GENERAL_NEWS)
+                    fcmTokenPersistencePort.atomicUpdateTopic(match {
+                        it.fcmToken == noticeTopicUpdateCommand.fcmToken &&
+                        it.topicType == noticeTopicUpdateCommand.topicType &&
+                        it.topic == noticeTopicUpdateCommand.topic &&
+                        !it.enabled
                     })
                 }
             }
-
-            // TODO : 앱 기능 추가 후 활성화
-//            Then("STUDENT_CAFETERIA Topic 제거") {
-//                val result = fcmTokenCommandService.updateTopic(mealTopicUpdateCommand)
-//                result shouldBe true
-//
-//                verify(exactly = 1) {
-//                    fcmTokenPersistencePort.saveFcmToken(match {
-//                        it.fcmToken == mealTopicUpdateCommand.fcmToken && !it.subscribedMealTopics.contains(
-//                            MealType.STUDENT_CAFETERIA)
-//                    })
-//                }
-//            }
         }
     }
 


### PR DESCRIPTION
## #️⃣ Issue Number


## 📝 요약(Summary)

두 요청이 동시에 같은 `Document` 를 읽는 경우
나중에 저장되는 요청이 먼저 저장된 변경사항을 덮어쓰는 `Lost Update` 문제가 발생


MongoDB $addToSet/$pull 원자적 연산으로 교체해
DB 수준의 `Write lock` 으로 `Lost update` 방지하도록 수정


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 버그 수정
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



