### PR TITLE
feat: /open-api/v2 정수형 topic 공지 조회 API 추가

### DIFF
--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/NoticeOpenApiV2Adapter.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/NoticeOpenApiV2Adapter.kt
@@ -1,0 +1,37 @@
+package com.fx.api.adapter.`in`.web
+
+import com.fx.api.adapter.`in`.web.dto.notice.NoticeResponseV2
+import com.fx.api.adapter.`in`.web.dto.notice.NoticeSearchParamV2
+import com.fx.api.adapter.`in`.web.swagger.NoticeOpenApiV2Swagger
+import com.fx.api.application.port.`in`.NoticeQueryUseCase
+import com.fx.global.annotation.hexagonal.WebInputAdapter
+import io.github.seob7.Api
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+
+@WebInputAdapter
+@RequestMapping("/open-api/v2/notices")
+class NoticeOpenApiV2Adapter(
+    private val noticeQueryUseCase: NoticeQueryUseCase
+) : NoticeOpenApiV2Swagger {
+
+    @GetMapping
+    override fun getNotices(
+        @ModelAttribute noticeSearchParamV2: NoticeSearchParamV2,
+        @PageableDefault(sort = ["nttId"], direction = Sort.Direction.DESC, size = 20) pageable: Pageable
+    ): ResponseEntity<Api<List<NoticeResponseV2>>> =
+        Api.OK(NoticeResponseV2.from(
+            noticeQueryUseCase.getNotices(noticeSearchParamV2.toCommand(pageable)))
+        )
+
+    @GetMapping("/{nttId}")
+    override fun getNotice(@PathVariable nttId: Long): ResponseEntity<Api<NoticeResponseV2>> =
+        Api.OK(NoticeResponseV2.from(noticeQueryUseCase.getNotice(nttId)))
+
+}

--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeResponseV2.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeResponseV2.kt
@@ -1,0 +1,39 @@
+package com.fx.api.adapter.`in`.web.dto.notice
+
+import com.fx.global.domain.Notice
+import java.time.LocalDate
+
+data class NoticeResponseV2(
+
+    val nttId: Long,
+    val title: String,
+    val contentUrl: String,
+    val contentImageUrl: String? = null,
+    val isContentSummary: Boolean,
+    val department: String,
+    val registrationDate: LocalDate,
+    val isAttachment: Boolean,
+    val topic: Int
+
+) {
+
+    companion object {
+
+        fun from(notice: Notice): NoticeResponseV2 =
+            NoticeResponseV2(
+                nttId = notice.nttId,
+                title = notice.title,
+                contentUrl = notice.contentUrl,
+                contentImageUrl = notice.contentImageUrl,
+                isContentSummary = notice.contentSummary != null,
+                department = notice.department,
+                registrationDate = notice.registrationDate,
+                isAttachment = notice.isAttachment,
+                topic = notice.topic.code
+            )
+
+        fun from(notices: List<Notice>): List<NoticeResponseV2> =
+            notices.map { this.from(it) }
+    }
+
+}

--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeSearchParamV2.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeSearchParamV2.kt
@@ -17,18 +17,8 @@ data class NoticeSearchParamV2(
     fun toCommand(pageable: Pageable) =
         NoticeQuery(
             nttId = this.nttId,
-            topic = topic?.let { resolveTopicCode(it) },
+            topic = topic?.let { CrawlableType.fromCode(it) },
             keyword = this.keyword,
             pageable = pageable
         )
-
-    private fun resolveTopicCode(code: Int): CrawlableType {
-        val type = try {
-            CrawlableType.fromCode(code)
-        } catch (e: IllegalArgumentException) {
-            throw TopicException(TopicErrorCode.INVALID_TOPIC_CODE, e)
-        }
-        if (type is MealType) throw TopicException(TopicErrorCode.INVALID_TOPIC_CODE)
-        return type
-    }
 }

--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeSearchParamV2.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeSearchParamV2.kt
@@ -1,0 +1,21 @@
+package com.fx.api.adapter.`in`.web.dto.notice
+
+import com.fx.api.domain.NoticeQuery
+import com.fx.global.domain.CrawlableType
+import org.springframework.data.domain.Pageable
+
+data class NoticeSearchParamV2(
+
+    val nttId: Long? = null,
+    val topic: Int? = null,
+    val keyword: String? = null
+
+) {
+    fun toCommand(pageable: Pageable) =
+        NoticeQuery(
+            nttId = this.nttId,
+            topic = topic?.let { CrawlableType.fromCode(it) },
+            keyword = this.keyword,
+            pageable = pageable
+        )
+}

--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeSearchParamV2.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/notice/NoticeSearchParamV2.kt
@@ -2,6 +2,9 @@ package com.fx.api.adapter.`in`.web.dto.notice
 
 import com.fx.api.domain.NoticeQuery
 import com.fx.global.domain.CrawlableType
+import com.fx.global.domain.MealType
+import com.fx.global.exception.TopicException
+import com.fx.global.exception.errorcode.TopicErrorCode
 import org.springframework.data.domain.Pageable
 
 data class NoticeSearchParamV2(
@@ -14,8 +17,18 @@ data class NoticeSearchParamV2(
     fun toCommand(pageable: Pageable) =
         NoticeQuery(
             nttId = this.nttId,
-            topic = topic?.let { CrawlableType.fromCode(it) },
+            topic = topic?.let { resolveTopicCode(it) },
             keyword = this.keyword,
             pageable = pageable
         )
+
+    private fun resolveTopicCode(code: Int): CrawlableType {
+        val type = try {
+            CrawlableType.fromCode(code)
+        } catch (e: IllegalArgumentException) {
+            throw TopicException(TopicErrorCode.INVALID_TOPIC_CODE, e)
+        }
+        if (type is MealType) throw TopicException(TopicErrorCode.INVALID_TOPIC_CODE)
+        return type
+    }
 }

--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/swagger/NoticeOpenApiV2Swagger.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/swagger/NoticeOpenApiV2Swagger.kt
@@ -1,0 +1,57 @@
+package com.fx.api.adapter.`in`.web.swagger
+
+import com.fx.api.adapter.`in`.web.dto.notice.NoticeResponseV2
+import com.fx.api.adapter.`in`.web.dto.notice.NoticeSearchParamV2
+import com.fx.global.exception.errorcode.NoticeErrorCode
+import com.fx.global.annotation.ApiExceptionExplanation
+import com.fx.global.annotation.ApiResponseExplanations
+import io.github.seob7.Api
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+
+@Tag(name = "공지 API")
+interface NoticeOpenApiV2Swagger {
+
+    @ApiResponseExplanations(
+        errors = [
+            ApiExceptionExplanation(
+                name = "공지 목록 조회 실패",
+                description = "서버에 다음 공지가 존재하지 않는 경우",
+                value = NoticeErrorCode::class,
+                constant = "NOTICE_NOT_FOUND"
+            ),
+        ]
+    )
+    @Operation(
+        summary = "공지 목록을 조회/검색합니다. (정수형 topic)",
+        description = "ex) /open-api/v2/notices?topic=1&size=5&nttId=1081908&keyword=파이썬&sort=nttId,DESC <br>" +
+                "[DEFAULT : sort=nttId,DESC&size=20] <br><br>" +
+                "NoticeType: GENERAL_NEWS=1, SCHOLARSHIP_NEWS=2, EVENT_NEWS=3, ACADEMIC_NEWS=4, EMPLOYMENT_NEWS=5 <br>" +
+                "MajorType: 공과대학 100~113, 교통공과대학 200~202, AI융합대학 300~303, 인문대학 400~405, " +
+                "사회과학대학 500~509, 보건생명대학 600~607, 철도대학 700~706, 미래융합대학 800~805"
+    )
+    fun getNotices(
+        @ModelAttribute noticeSearchParamV2: NoticeSearchParamV2,
+        @PageableDefault(sort = ["nttId"], direction = Sort.Direction.DESC, size = 20) pageable: Pageable
+    ): ResponseEntity<Api<List<NoticeResponseV2>>>
+
+    @ApiResponseExplanations(
+        errors = [
+            ApiExceptionExplanation(
+                name = "단일 공지 조회 실패",
+                description = "서버에 해당하는 공지가 존재하지 않는 경우",
+                value = NoticeErrorCode::class,
+                constant = "NOTICE_NOT_FOUND"
+            ),
+        ]
+    )
+    @Operation(summary = "단일 공지 조회 (정수형 topic)", description = "nttId 로 공지를 조회합니다.")
+    fun getNotice(@PathVariable nttId: Long): ResponseEntity<Api<NoticeResponseV2>>
+
+}

--- a/global/src/main/kotlin/com/fx/global/domain/CrawlableType.kt
+++ b/global/src/main/kotlin/com/fx/global/domain/CrawlableType.kt
@@ -5,19 +5,26 @@ interface CrawlableType {
     val bbsPath: String
     val category: String
     val topicName: String // DB에 저장할 이름 ex) GENERAL_NEWS, EVENT_NEWS....
+    val code: Int
     fun getNoticeUrl(): String = "$rootDomain$bbsPath"
 
     companion object {
         // ex) {GENERAL_NEWS: NoticeType.GENERAL_NEWS, COMPUTER_SCIENCE: MajorType.COMPUTER_SCIENCE...}
         private val registry = mutableMapOf<String, CrawlableType>()
+        private val codeRegistry = mutableMapOf<Int, CrawlableType>()
 
         fun register(type: CrawlableType) {
             registry[type.topicName] = type
+            codeRegistry[type.code] = type
         }
 
         @JvmStatic
         fun fromString(topicName: String): CrawlableType =
             registry[topicName] ?: throw IllegalArgumentException("Unknown type: $topicName")
+
+        @JvmStatic
+        fun fromCode(code: Int): CrawlableType =
+            codeRegistry[code] ?: throw IllegalArgumentException("Unknown code: $code")
 
         @JvmStatic
         fun allTypeNames(): Set<String> = registry.keys

--- a/global/src/main/kotlin/com/fx/global/domain/CrawlableType.kt
+++ b/global/src/main/kotlin/com/fx/global/domain/CrawlableType.kt
@@ -1,5 +1,8 @@
 package com.fx.global.domain
 
+import com.fx.global.exception.TopicException
+import com.fx.global.exception.errorcode.TopicErrorCode
+
 interface CrawlableType {
     val rootDomain: String
     val bbsPath: String
@@ -20,11 +23,11 @@ interface CrawlableType {
 
         @JvmStatic
         fun fromString(topicName: String): CrawlableType =
-            registry[topicName] ?: throw IllegalArgumentException("Unknown type: $topicName")
+            registry[topicName] ?: throw TopicException(TopicErrorCode.TOPIC_NOT_FOUND)
 
         @JvmStatic
         fun fromCode(code: Int): CrawlableType =
-            codeRegistry[code] ?: throw IllegalArgumentException("Unknown code: $code")
+            codeRegistry[code] ?: throw TopicException(TopicErrorCode.TOPIC_NOT_FOUND)
 
         @JvmStatic
         fun allTypeNames(): Set<String> = registry.keys

--- a/global/src/main/kotlin/com/fx/global/domain/MajorType.kt
+++ b/global/src/main/kotlin/com/fx/global/domain/MajorType.kt
@@ -6,6 +6,7 @@ package com.fx.global.domain
  * ENUM 에 포함된 학과는 서버에서 자동 크롤링 대상이 됨
  */
 enum class MajorType(
+    override val code: Int,
     override val rootDomain: String,
     override val bbsPath: String,
     override val category: String,
@@ -29,6 +30,7 @@ enum class MajorType(
      * - 1.7.x 버전에서 사용중이므로 추후 주석 OR 제거 필요
      */
     AI_ROBOTICS_ENGINEERING(
+        10,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001156/selectBoardList.do",
         "AI로봇공학과",
@@ -36,6 +38,7 @@ enum class MajorType(
     ),
 
     BIOMEDICAL_ENGINEERING(
+        11,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001139/selectBoardList.do",
         "바이오메디컬융합학과",
@@ -43,6 +46,7 @@ enum class MajorType(
     ),
 
     PRECISION_MEDICINE_MEDICAL_DEVICE(
+        12,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001382/selectBoardList.do",
         "정밀의료·의료기기학과",
@@ -52,6 +56,7 @@ enum class MajorType(
 
     // ---------- 공과대학 | College of Engineering ----------
     MECHANICAL_ENGINEERING(
+        100,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000219/selectBoardList.do",
         "기계공학과",
@@ -59,6 +64,7 @@ enum class MajorType(
     ),
 
     ELECTRICAL_ENGINEERING(
+        101,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000235/selectBoardList.do",
         "전기공학과",
@@ -66,6 +72,7 @@ enum class MajorType(
     ),
 
     ELECTRONIC_ENGINEERING(
+        102,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000244/selectBoardList.do",
         "전자공학과",
@@ -73,6 +80,7 @@ enum class MajorType(
     ),
 
     CIVIL_ENGINEERING(
+        103,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000259/selectBoardList.do",
         "사회기반공학전공",
@@ -80,6 +88,7 @@ enum class MajorType(
     ),
 
     ENVIRONMENTAL_ENGINEERING(
+        104,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000264/selectBoardList.do",
         "환경공학전공",
@@ -87,6 +96,7 @@ enum class MajorType(
     ),
 
     URBAN_AND_TRANSPORTATION_ENGINEERING(
+        105,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000269/selectBoardList.do",
         "도시·교통공학전공",
@@ -94,6 +104,7 @@ enum class MajorType(
     ),
 
     CHEMICAL_AND_BIOLOGICAL_ENGINEERING(
+        106,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000277/selectBoardList.do",
         "화공생물공학과",
@@ -101,6 +112,7 @@ enum class MajorType(
     ),
 
     MATERIALS_SCIENCE_AND_ENGINEERING(
+        107,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000281/selectBoardList.do",
         "반도체신소재공학과",
@@ -108,6 +120,7 @@ enum class MajorType(
     ),
 
     POLYMER_SCIENCE_AND_ENGINEERING(
+        108,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000285/selectBoardList.do",
         "나노화학소재공학과",
@@ -115,6 +128,7 @@ enum class MajorType(
     ),
 
     SAFETY_ENGINEERING(
+        109,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000304/selectBoardList.do",
         "안전공학과",
@@ -122,6 +136,7 @@ enum class MajorType(
     ),
 
     ARCHITECTURAL_ENGINEERING(
+        110,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000319/selectBoardList.do",
         "건축공학과",
@@ -129,6 +144,7 @@ enum class MajorType(
     ),
 
     ARCHITECTURE(
+        111,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000328/selectBoardList.do",
         "건축학과(5년제)",
@@ -136,6 +152,7 @@ enum class MajorType(
     ),
 
     COMMUNICATION_DESIGN(
+        112,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000342/selectBoardList.do",
         "커뮤니케이션디자인학과",
@@ -143,6 +160,7 @@ enum class MajorType(
     ),
 
     SCHOOL_OF_NANOMEDICAL_ENGINEERING(
+        113,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001501/selectBoardList.do",
         "나노메디컬공학부",
@@ -151,6 +169,7 @@ enum class MajorType(
 
     // ---------- 교통공과대학 | College of Transportation Engineering ----------
     AUTOMOTIVE_ENGINEERING(
+        200,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000222/selectBoardList.do",
         "자동차공학과",
@@ -158,6 +177,7 @@ enum class MajorType(
     ),
 
     AERONAUTICAL_AND_MECHANICAL_DESIGN_ENGINEERING(
+        201,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000226/selectBoardList.do",
         "항공·기계설계전공",
@@ -165,6 +185,7 @@ enum class MajorType(
     ),
 
     UNMANNED_AIRCRAFT_SYSTEM_ENGINEERING(
+        202,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001503/selectBoardList.do",
         "드론공학전공",
@@ -173,6 +194,7 @@ enum class MajorType(
 
     // ---------- AI융합대학 | College of AI Convergence ----------
     COMPUTER_ENGINEERING(
+        300,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000352/selectBoardList.do",
         "컴퓨터공학과",
@@ -180,6 +202,7 @@ enum class MajorType(
     ),
 
     COMPUTER_SCIENCE(
+        301,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000360/selectBoardList.do",
         "컴퓨터소프트웨어학과",
@@ -187,6 +210,7 @@ enum class MajorType(
     ),
 
     INDUSTRIAL_AND_MANAGEMENT_ENGINEERING(
+        302,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000301/selectBoardList.do",
         "산업경영공학과",
@@ -194,6 +218,7 @@ enum class MajorType(
     ),
 
     INDUSTRIAL_DESIGN(
+        303,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000337/selectBoardList.do",
         "산업디자인학과",
@@ -202,6 +227,7 @@ enum class MajorType(
 
     // ---------- 인문대학 | College of Humanities ----------
     ENGLISH_LANGUAGE_AND_LITERATURE(
+        400,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000376/selectBoardList.do",
         "영어영문학과",
@@ -209,6 +235,7 @@ enum class MajorType(
     ),
 
     CHINESE_LANGUAGE(
+        401,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000385/selectBoardList.do",
         "중국어학과",
@@ -216,6 +243,7 @@ enum class MajorType(
     ),
 
     KOREAN_LANGUAGE_AND_LITERATURE(
+        402,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000390/selectBoardList.do",
         "한국어문학과",
@@ -223,6 +251,7 @@ enum class MajorType(
     ),
 
     MUSIC(
+        403,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000463/selectBoardList.do",
         "음악학과",
@@ -230,6 +259,7 @@ enum class MajorType(
     ),
 
     SPORTS_MEDICINE(
+        404,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000472/selectBoardList.do",
         "스포츠의학과",
@@ -237,6 +267,7 @@ enum class MajorType(
     ),
 
     SPORTS_INDUSTRY(
+        405,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000478/selectBoardList.do",
         "스포츠산업학과",
@@ -245,6 +276,7 @@ enum class MajorType(
 
     // ---------- 사회과학대학 | College of Social Sciences ----------
     PUBLIC_ADMINISTRATION(
+        500,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000397/selectBoardList.do",
         "행정학과",
@@ -252,6 +284,7 @@ enum class MajorType(
     ),
 
     PUBLIC_ADMINISTRATION_AND_INFORMATION_CONVERGENCE(
+        501,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000402/selectBoardList.do",
         "행정정보융합학과",
@@ -259,6 +292,7 @@ enum class MajorType(
     ),
 
     BUSINESS_ADMINISTRATION(
+        502,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000437/selectBoardList.do",
         "경영학과",
@@ -266,6 +300,7 @@ enum class MajorType(
     ),
 
     CONVERGENCE_MANAGEMENT(
+        503,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000446/selectBoardList.do",
         "융합경영학과",
@@ -273,6 +308,7 @@ enum class MajorType(
     ),
 
     INTERNATIONAL_TRADE_AND_BUSINESS(
+        504,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000451/selectBoardList.do",
         "국제무역학과",
@@ -280,6 +316,7 @@ enum class MajorType(
     ),
 
     SOCIAL_WELFARE(
+        505,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000458/selectBoardList.do",
         "사회복지학과",
@@ -287,6 +324,7 @@ enum class MajorType(
     ),
 
     AIRLINE_SERVICE(
+        506,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000483/selectBoardList.do",
         "항공서비스학과",
@@ -294,6 +332,7 @@ enum class MajorType(
     ),
 
     AERONAUTICAL_SCIENCE_AND_FLIGHT_OPERATION(
+        507,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000487/selectBoardList.do",
         "항공운항학과",
@@ -301,6 +340,7 @@ enum class MajorType(
     ),
 
     EARLY_CHILDHOOD_EDUCATION(
+        508,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000492/selectBoardList.do",
         "유아교육학과",
@@ -308,6 +348,7 @@ enum class MajorType(
     ),
 
     MEDIA_AND_CONTENTS(
+        509,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001147/selectBoardList.do",
         "미디어&콘텐츠학과",
@@ -316,6 +357,7 @@ enum class MajorType(
 
     // ---------- 보건생명대학 | College of Health and Life Science ----------
     NURSING(
+        600,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000592/selectBoardList.do",
         "간호학과",
@@ -323,6 +365,7 @@ enum class MajorType(
     ),
 
     PHYSICAL_THERAPY(
+        601,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000534/selectBoardList.do",
         "물리치료학과",
@@ -330,6 +373,7 @@ enum class MajorType(
     ),
 
     PARAMEDICINE(
+        602,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000538/selectBoardList.do",
         "응급구조학과",
@@ -337,6 +381,7 @@ enum class MajorType(
     ),
 
     FOOD_SCIENCE_AND_TECHNOLOGY(
+        603,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000518/selectBoardList.do",
         "식품공학전공",
@@ -344,6 +389,7 @@ enum class MajorType(
     ),
 
     FOOD_AND_NUTRITION(
+        604,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000523/selectBoardList.do",
         "식품영양학전공",
@@ -351,6 +397,7 @@ enum class MajorType(
     ),
 
     BIOTECHNOLOGY(
+        605,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000528/selectBoardList.do",
         "생명공학전공",
@@ -358,6 +405,7 @@ enum class MajorType(
     ),
 
     EARLY_CHILDHOOD_SPECIAL_EDUCATION(
+        606,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000544/selectBoardList.do",
         "유아특수교육학과",
@@ -365,6 +413,7 @@ enum class MajorType(
     ),
 
     IT_APPLIED_CONVERGENCE(
+        607,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000550/selectBoardList.do",
         "IT응용융합학과",
@@ -373,6 +422,7 @@ enum class MajorType(
 
     // ---------- 철도대학 | College of Railroad Sciences ----------
     RAILROAD_MANAGEMENT_AND_LOGISTICS(
+        700,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000557/selectBoardList.do",
         "철도경영·물류학과",
@@ -380,6 +430,7 @@ enum class MajorType(
     ),
 
     DATA_SCIENCE(
+        701,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000561/selectBoardList.do",
         "철도데이터사이언스전공",
@@ -387,6 +438,7 @@ enum class MajorType(
     ),
 
     ARTIFICIAL_INTELLIGENCE(
+        702,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001163/selectBoardList.do",
         "철도인공지능전공",
@@ -394,6 +446,7 @@ enum class MajorType(
     ),
 
     RAILROAD_OPERATION_SYSTEMS_ENGINEERING(
+        703,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000572/selectBoardList.do",
         "철도운전시스템공학과",
@@ -401,6 +454,7 @@ enum class MajorType(
     ),
 
     RAILWAY_VEHICLE_SYSTEM_ENGINEERING(
+        704,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000576/selectBoardList.do",
         "철도차량시스템공학과",
@@ -408,6 +462,7 @@ enum class MajorType(
     ),
 
     RAILROAD_INFRASTRUCTURE_ENGINEERING(
+        705,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000580/selectBoardList.do",
         "철도인프라공학과",
@@ -415,6 +470,7 @@ enum class MajorType(
     ),
 
     RAILROAD_ELECTRICAL_AND_INFORMATION_ENGINEERING(
+        706,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000584/selectBoardList.do",
         "철도전기정보공학과",
@@ -423,6 +479,7 @@ enum class MajorType(
 
     // ---------- 미래융합대학 | College of Future Convergence ----------
     SAFETY_CONVERGENCE_ENGINEERING(
+        800,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001181/selectBoardList.do",
         "안전융합공학과",
@@ -430,6 +487,7 @@ enum class MajorType(
     ),
 
     CONSTRUCTION_AND_DISASTER_PREVENTION_CONVERGENCE_ENGINEERING(
+        801,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001052/selectBoardList.do",
         "건설방재융합공학과",
@@ -437,6 +495,7 @@ enum class MajorType(
     ),
 
     SPORT_WELFARE(
+        802,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001053/selectBoardList.do",
         "스포츠복지학과",
@@ -444,6 +503,7 @@ enum class MajorType(
     ),
 
     WELFARE_AND_MANAGEMENT(
+        803,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001054/selectBoardList.do",
         "복지·경영학과",
@@ -451,6 +511,7 @@ enum class MajorType(
     ),
 
     SMART_RAILWAY_AND_TRANSPORTATION_ENGINEERING(
+        804,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001184/selectBoardList.do",
         "스마트철도교통공학과",
@@ -458,6 +519,7 @@ enum class MajorType(
     ),
 
     SECONDARY_BATTERY_ENGINEERING(
+        805,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000001351/selectBoardList.do",
         "이차전지공학과",

--- a/global/src/main/kotlin/com/fx/global/domain/MealType.kt
+++ b/global/src/main/kotlin/com/fx/global/domain/MealType.kt
@@ -1,18 +1,21 @@
 package com.fx.global.domain
 
 enum class MealType(
+    override val code: Int,
     override val rootDomain: String,
     override val bbsPath: String,
     override val category: String
 ) : CrawlableType {
 
     STUDENT_CAFETERIA(
+        900,
         "https://www.ut.ac.kr",
         "/prog/mealManage/MT01/kor/sub06_02_02_01/dayList.do",
         "학생식당"
     ),
 
     STAFF_CAFETERIA(
+        901,
         "https://www.ut.ac.kr",
         "/prog/mealManage/MT02/kor/sub06_02_02_02/dayList.do",
         "교직원식당"

--- a/global/src/main/kotlin/com/fx/global/domain/NoticeType.kt
+++ b/global/src/main/kotlin/com/fx/global/domain/NoticeType.kt
@@ -1,37 +1,42 @@
 package com.fx.global.domain
 
 enum class NoticeType(
+    override val code: Int,
     override val rootDomain: String,
     override val bbsPath: String,
     override val category: String
 ) : CrawlableType {
 
-
     GENERAL_NEWS(
+        1,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000059/selectBoardList.do",
         "일반소식"
     ),
 
     SCHOLARSHIP_NEWS(
+        2,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000060/selectBoardList.do",
         "장학안내"
     ),
 
     EVENT_NEWS(
+        3,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000061/selectBoardList.do",
         "행사안내"
     ),
 
     ACADEMIC_NEWS(
+        4,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000055/selectBoardList.do",
         "학사공지사항"
     ),
 
     EMPLOYMENT_NEWS(
+        5,
         "https://www.ut.ac.kr",
         "/cop/bbs/BBSMSTR_000000000179/selectBoardList.do",
         "취업지원안내"

--- a/global/src/main/kotlin/com/fx/global/exception/errorcode/TopicErrorCode.kt
+++ b/global/src/main/kotlin/com/fx/global/exception/errorcode/TopicErrorCode.kt
@@ -8,8 +8,7 @@ enum class TopicErrorCode(
     private val message: String
 ) : BaseErrorCode {
 
-    TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 구독입니다."),
-    INVALID_TOPIC_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 토픽 코드입니다.")
+    TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 구독입니다.")
     ;
 
     override fun getHttpStatus(): HttpStatus = httpStatus

--- a/global/src/main/kotlin/com/fx/global/exception/errorcode/TopicErrorCode.kt
+++ b/global/src/main/kotlin/com/fx/global/exception/errorcode/TopicErrorCode.kt
@@ -8,7 +8,8 @@ enum class TopicErrorCode(
     private val message: String
 ) : BaseErrorCode {
 
-    TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 구독입니다.")
+    TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 구독입니다."),
+    INVALID_TOPIC_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 토픽 코드입니다.")
     ;
 
     override fun getHttpStatus(): HttpStatus = httpStatus


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

클라이언트에서 문자열 대신 정수형 코드로 topic을 전달할 수 있도록
`/open-api/v2/notices` API를 추가했습니다.

기존 v1은 `topic=GENERAL_NEWS` 형태였지만,
v2는 `topic=1` 형태로 요청할 수 있습니다.

DB 구조는 변경 없이 메모리 내 Map으로 정수 코드 → 타입 변환을 처리합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항

**정수 코드표**

| 코드 | 타입 |
|---|---|
| 1 | GENERAL_NEWS |
| 2 | SCHOLARSHIP_NEWS |
| 3 | EVENT_NEWS |
| 4 | ACADEMIC_NEWS |
| 5 | EMPLOYMENT_NEWS |
| 100~113 | 공과대학 전공 |
| 200~202 | 교통공과대학 전공 |
| 300~303 | AI융합대학 전공 |
| 400~405 | 인문대학 전공 |
| 500~509 | 사회과학대학 전공 |
| 600~607 | 보건생명대학 전공 |
| 700~706 | 철도대학 전공 |
| 800~805 | 미래융합대학 전공 |

MealType(900, 901)은 v2에서 사용 불가 처리(400 반환)했습니다.

## 📸 스크린샷 (선택)

**정상 응답 (topic=1, GENERAL_NEWS)**
<img width="1429" height="1050" alt="image" src="https://github.com/user-attachments/assets/1909849c-9e64-471f-bef2-e869dc1bd972" />

**잘못된 코드 입력 시 400 응답 (topic=999)**
<img width="1425" height="851" alt="image" src="https://github.com/user-attachments/assets/1f094af4-6c56-458c-99a2-80f43ad1a7cf" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)