### PR TITLE
feat: /open-api/v1/topics/types API에 topicId 조회 기능 추가

### DIFF
--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/TopicOpenApiAdapter.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/TopicOpenApiAdapter.kt
@@ -6,8 +6,11 @@ import com.fx.api.adapter.`in`.web.dto.topic.TypeResponse
 import com.fx.api.adapter.`in`.web.swagger.TopicOpenApiSwagger
 import com.fx.api.application.port.`in`.FcmTokenCommandUseCase
 import com.fx.api.application.port.`in`.FcmTokenQueryUseCase
+import com.fx.global.domain.CrawlableType
 import com.fx.global.domain.TopicType
 import com.fx.global.annotation.hexagonal.WebInputAdapter
+import com.fx.global.exception.TopicException
+import com.fx.global.exception.errorcode.TopicErrorCode
 import io.github.seob7.Api
 import jakarta.validation.Valid
 import org.springframework.context.MessageSource
@@ -44,9 +47,16 @@ class TopicOpenApiAdapter(
     @GetMapping("/types")
     override fun getTopicsByType(
         @RequestHeader(value = "Accept-Language", required = false, defaultValue = "ko-KR") acceptLanguage: String,
-        @RequestParam type: TopicType
+        @RequestParam(required = false) type: TopicType?,
+        @RequestParam(required = false) topic: String?,
+        @RequestParam(required = false) topicId: Int?
     ): ResponseEntity<Api<List<TypeResponse>>> {
-        val responses = when (type) {
+        if (topic != null || topicId != null) {
+            val resolved = topicId?.let { CrawlableType.fromCode(it) } ?: CrawlableType.fromString(topic!!)
+            return Api.OK(listOf(TypeResponse.from(resolved, messageSource)))
+        }
+
+        val responses = when (type ?: throw TopicException(TopicErrorCode.TOPIC_NOT_FOUND)) {
             TopicType.NOTICE -> TypeResponse.fromNoticeTypes()
             TopicType.MAJOR -> TypeResponse.fromMajorTypes(messageSource)
             TopicType.MEAL -> TypeResponse.fromMealTypes()

--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/topic/TypeResponse.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/dto/topic/TypeResponse.kt
@@ -1,6 +1,7 @@
 package com.fx.api.adapter.`in`.web.dto.topic
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fx.global.domain.CrawlableType
 import com.fx.global.domain.MajorType
 import com.fx.global.domain.MealType
 import com.fx.global.domain.NoticeType
@@ -10,18 +11,20 @@ import org.springframework.context.i18n.LocaleContextHolder
 //@JsonInclude(JsonInclude.Include.NON_NULL) // dslee - null 인 필드는 응답에서 제외함
 data class TypeResponse(
     val topic: String,
+    val topicId: Int,
     val name: String,
     val college: String? = null
 ) {
     companion object {
         fun fromNoticeTypes(): List<TypeResponse> =
-            NoticeType.entries.map { TypeResponse(topic = it.name, name = it.category) }
+            NoticeType.entries.map { TypeResponse(topic = it.name, topicId = it.code, name = it.category) }
 
         fun fromMajorTypes(messageSource: MessageSource): List<TypeResponse> {
             return MajorType.entries.map {
                 val locale = LocaleContextHolder.getLocale()
                 TypeResponse(
                     topic = it.name,
+                    topicId = it.code,
                     name = messageSource.getMessage("topic.${it.name.lowercase()}", null, it.category, locale) ?: it.category,
                     college = messageSource.getMessage("college.${it.college.lowercase()}", null, it.college, locale) ?: it.college
                 )
@@ -29,6 +32,20 @@ data class TypeResponse(
         }
 
         fun fromMealTypes(): List<TypeResponse> =
-            MealType.entries.map { TypeResponse(topic = it.name, name = it.category) }
+            MealType.entries.map { TypeResponse(topic = it.name, topicId = it.code, name = it.category) }
+
+        fun from(type: CrawlableType, messageSource: MessageSource): TypeResponse =
+            when (type) {
+                is MajorType -> {
+                    val locale = LocaleContextHolder.getLocale()
+                    TypeResponse(
+                        topic = type.topicName,
+                        topicId = type.code,
+                        name = messageSource.getMessage("topic.${type.name.lowercase()}", null, type.category, locale) ?: type.category,
+                        college = messageSource.getMessage("college.${type.college.lowercase()}", null, type.college, locale) ?: type.college
+                    )
+                }
+                else -> TypeResponse(topic = type.topicName, topicId = type.code, name = type.category)
+            }
     }
 }

--- a/api/src/main/kotlin/com/fx/api/adapter/in/web/swagger/TopicOpenApiSwagger.kt
+++ b/api/src/main/kotlin/com/fx/api/adapter/in/web/swagger/TopicOpenApiSwagger.kt
@@ -56,7 +56,20 @@ interface TopicOpenApiSwagger {
         @RequestBody @Valid topicUpdateRequest: TopicUpdateRequest
     ): ResponseEntity<Api<Boolean>>
 
-    @Operation(summary = "Type 별 Topic 조회", description = "각 타입의 토픽들을 조회합니다.")
+    @ApiResponseExplanations(
+        errors = [
+            ApiExceptionExplanation(
+                name = "유효하지 않은 Topic",
+                description = "type 이 없고 topic/topicId 도 없거나, 서버에 존재하지 않는 topic/topicId 인 경우",
+                value = TopicErrorCode::class,
+                constant = "TOPIC_NOT_FOUND"
+            ),
+        ]
+    )
+    @Operation(
+        summary = "Type 별 Topic 조회",
+        description = "각 타입의 토픽들을 조회합니다.<br> type 만 주어지면 해당 카테고리(NOTICE, MAJOR, MEAL)의 전체 토픽을 반환합니다.<br> topic 또는 topicId 가 주어지면 해당 토픽 하나만 반환합니다."
+    )
     fun getTopicsByType(
         @Parameter(
             name = "Accept-Language",
@@ -65,7 +78,12 @@ interface TopicOpenApiSwagger {
             schema = Schema(type = "string", allowableValues = ["ko-KR", "en-US", "ja-JP"], defaultValue = "ko-KR")
         )
         @RequestHeader(value = "Accept-Language", required = false, defaultValue = "ko-KR") acceptLanguage: String,
-        @RequestParam type: TopicType
+        @Parameter(description = "조회할 토픽 카테고리 (topic/topicId 미지정 시 필수)")
+        @RequestParam(required = false) type: TopicType?,
+        @Parameter(description = "조회할 토픽 이름 (ex. GENERAL_NEWS)")
+        @RequestParam(required = false) topic: String?,
+        @Parameter(description = "조회할 토픽 정수 코드")
+        @RequestParam(required = false) topicId: Int?
     ): ResponseEntity<Api<List<TypeResponse>>>
 
 }

--- a/api/src/test/kotlin/com/fx/api/adapter/in/web/dto/topic/TypeResponseTest.kt
+++ b/api/src/test/kotlin/com/fx/api/adapter/in/web/dto/topic/TypeResponseTest.kt
@@ -1,0 +1,114 @@
+package com.fx.api.adapter.`in`.web.dto.topic
+
+import com.fx.global.domain.CrawlableType
+import com.fx.global.domain.MajorType
+import com.fx.global.domain.MealType
+import com.fx.global.domain.NoticeType
+import com.fx.global.exception.TopicException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.context.MessageSource
+
+class TypeResponseTest : BehaviorSpec({
+
+    // CrawlableType 은 각 enum 의 init 블록에서 스스로를 등록하므로,
+    // fromString/fromCode 를 쓰기 전에 enum 클래스를 먼저 로드해서 등록을 강제한다.
+    NoticeType.entries
+    MajorType.entries
+    MealType.entries
+
+    val messageSource = mockk<MessageSource>()
+    every { messageSource.getMessage(any(), any(), any<String>(), any()) } answers { thirdArg() }
+
+    Given("topic 이름으로 단건 조회") {
+        When("존재하는 NoticeType 이름이면") {
+            val resolved = CrawlableType.fromString("GENERAL_NEWS")
+            val response = TypeResponse.from(resolved, messageSource)
+
+            Then("topic, topicId, name 이 NoticeType 의 값과 일치한다") {
+                response.topic shouldBe "GENERAL_NEWS"
+                response.topicId shouldBe NoticeType.GENERAL_NEWS.code
+                response.name shouldBe NoticeType.GENERAL_NEWS.category
+                response.college shouldBe null
+            }
+        }
+
+        When("존재하지 않는 topic 이름이면") {
+            Then("TopicException 발생") {
+                shouldThrow<TopicException> { CrawlableType.fromString("NOT_EXIST_TOPIC") }
+            }
+        }
+    }
+
+    Given("topicId 로 단건 조회") {
+        When("존재하는 NoticeType code 이면") {
+            val resolved = CrawlableType.fromCode(NoticeType.GENERAL_NEWS.code)
+            val response = TypeResponse.from(resolved, messageSource)
+
+            Then("topic 문자열 이름으로 정상 변환된다") {
+                response.topic shouldBe "GENERAL_NEWS"
+                response.topicId shouldBe NoticeType.GENERAL_NEWS.code
+            }
+        }
+
+        When("존재하는 MajorType code 이면") {
+            val resolved = CrawlableType.fromCode(MajorType.COMPUTER_ENGINEERING.code)
+            val response = TypeResponse.from(resolved, messageSource)
+
+            Then("college 필드까지 채워진다") {
+                response.topic shouldBe "COMPUTER_ENGINEERING"
+                response.topicId shouldBe MajorType.COMPUTER_ENGINEERING.code
+                response.college shouldBe MajorType.COMPUTER_ENGINEERING.college
+            }
+        }
+
+        When("존재하지 않는 topicId 이면") {
+            Then("TopicException 발생") {
+                shouldThrow<TopicException> { CrawlableType.fromCode(9999) }
+            }
+        }
+    }
+
+    Given("type(카테고리) 기준 전체 목록 조회 - 하위 호환") {
+        When("NoticeType 전체 조회") {
+            val responses = TypeResponse.fromNoticeTypes()
+
+            Then("모든 항목에 topicId 가 채워진 채로 반환된다") {
+                responses shouldHaveSize NoticeType.entries.size
+                responses.forEach { response ->
+                    val expected = NoticeType.valueOf(response.topic)
+                    response.topicId shouldBe expected.code
+                }
+            }
+        }
+
+        When("MealType 전체 조회") {
+            val responses = TypeResponse.fromMealTypes()
+
+            Then("모든 항목에 topicId 가 채워진 채로 반환된다") {
+                responses shouldHaveSize MealType.entries.size
+                responses.forEach { response ->
+                    val expected = MealType.valueOf(response.topic)
+                    response.topicId shouldBe expected.code
+                }
+            }
+        }
+
+        When("MajorType 전체 조회") {
+            val responses = TypeResponse.fromMajorTypes(messageSource)
+
+            Then("모든 항목에 topicId, college 가 채워진 채로 반환된다") {
+                responses shouldHaveSize MajorType.entries.size
+                responses.forEach { response ->
+                    val expected = MajorType.valueOf(response.topic)
+                    response.topicId shouldBe expected.code
+                    response.college shouldBe expected.college
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

클라이언트 요구사항이 추가되어 `/open-api/v1/topics/types` API에 topicId 조회를 추가했습니다.

기존 v1은 `topic`(문자열) 파라미터로만 조회 가능했지만, `topicId`(정수) 파라미터로도 동일한 토픽을 조회할 수 있도록 수정했고, 응답에도 `topicId`가 항상 포함되도록 변경했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항

파라미터 조합별 동작은 아래와 같습니다.

| 파라미터 조합 | 동작 | 응답 |
|---|---|---|
| type만 | 기존과 동일 — 카테고리 전체 목록 반환 | 200, 리스트 (topicId 포함) |
| topic만 | 해당 topic 이름 단건 조회 | 200, 단건 리스트 |
| topicId만 | 해당 topicId 단건 조회 | 200, 단건 리스트 |
| type/topic/topicId 모두 없음 | 잘못된 요청 | 404, TOPIC_NOT_FOUND |
| 존재하지 않는 topic/topicId | 잘못된 값 | 404, TOPIC_NOT_FOUND |

Service 단은 건드리지 않았고, 기존 `CrawlableType.fromCode()`/`fromString()` 매핑을 그대로 재사용했습니다.

## 📸스크린샷 (선택)

1. `GET /open-api/v1/topics/types?topic=GENERAL_NEWS` → 200, topicId:1 포함 응답
<img width="1308" height="741" alt="image" src="https://github.com/user-attachments/assets/433daa48-4913-4035-a3b8-84546a63d49d" />

2. `GET /open-api/v1/topics/types?topicId=1` → 200, 1번과 동일한 응답 (이름/숫자 둘 다 같은 결과 확인용)
<img width="1313" height="740" alt="image" src="https://github.com/user-attachments/assets/840aeefc-6e4b-48a7-a992-f919f86aa2a5" />

3. `GET /open-api/v1/topics/types?topicId=999` → 404, TOPIC_NOT_FOUND
<img width="1304" height="745" alt="image" src="https://github.com/user-attachments/assets/c2ef29ad-fd82-44b9-9864-8c513711c987" />


4. `GET /open-api/v1/topics/types` (파라미터 없음) → 404, TOPIC_NOT_FOUND
<img width="1303" height="737" alt="image" src="https://github.com/user-attachments/assets/6033261a-f63b-4471-a78a-e2d7a6fc790f" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)